### PR TITLE
Fix session export to include password for token refresh

### DIFF
--- a/src/zeekr_ev_api/client.py
+++ b/src/zeekr_ev_api/client.py
@@ -88,6 +88,7 @@ class ZeekrClient:
     def load_session(self, session_data: dict) -> None:
         """Loads a session from a dictionary."""
         self.username = session_data.get("username", "")
+        self.password = session_data.get("password") or self.password
         self.country_code = session_data.get("country_code", "AU")
         self.auth_token = session_data.get("auth_token")
         self.bearer_token = session_data.get("bearer_token")
@@ -114,6 +115,7 @@ class ZeekrClient:
 
         return {
             "username": self.username,
+            "password": self.password,
             "country_code": self.country_code,
             "auth_token": self.auth_token,
             "bearer_token": self.bearer_token,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -220,3 +220,38 @@ def test_appSignedPost_concurrent_header_leak(mock_client):
     # Check that each request had exactly its own VIN and not another one's
     extracted_vins = [h.get("X-VIN") for h in prepared_headers]
     assert set(extracted_vins) == set(vins), "Some requests sent mixed up or missing headers!"
+
+def test_export_and_load_session_with_password(mock_client):
+    """Test that password is included in exported session and restored when loading."""
+    mock_client.username = "test_user"
+    mock_client.password = "test_password"
+    mock_client.country_code = "US"
+    mock_client.logged_in = True
+
+    session_data = mock_client.export_session()
+
+    assert session_data.get("password") == "test_password"
+    assert session_data.get("username") == "test_user"
+
+    from zeekr_ev_api.client import ZeekrClient
+
+    new_client = ZeekrClient(session_data=session_data)
+    assert new_client.username == "test_user"
+    assert new_client.password == "test_password"
+    assert new_client.country_code == "US"
+
+def test_load_session_preserves_passed_password(mock_client):
+    """Test that load_session doesn't overwrite a passed password with None."""
+    from zeekr_ev_api.client import ZeekrClient
+
+    session_data = {
+        "username": "test_user",
+        "country_code": "US",
+        "bearer_token": "some_token"
+    }
+
+    new_client = ZeekrClient(password="explicit_password", session_data=session_data)
+
+    assert new_client.username == "test_user"
+    assert new_client.password == "explicit_password"
+    assert new_client.logged_in is True

--- a/tests/test_token_refresh.py
+++ b/tests/test_token_refresh.py
@@ -81,3 +81,56 @@ def test_token_refresh_refactor_retry_fails(client):
             network.appSignedGet(client, "http://test.url")
 
         assert "Token expired (retry failed)" in str(exc.value)
+
+def test_token_refresh_with_loaded_session(client):
+    """Test token refresh logic when a session is loaded from data."""
+    from zeekr_ev_api.client import ZeekrClient
+    from zeekr_ev_api.network import appSignedGet
+
+    session_data = {
+        "username": "test_user",
+        "password": "test_password",
+        "country_code": "US",
+        "bearer_token": "expired_token",
+        "auth_token": "auth_token_value"
+    }
+
+    # Initialize from session data (which has password)
+    new_client = ZeekrClient(session_data=session_data)
+
+    # Set up mocks
+    new_client.session = MagicMock()
+    new_client.logged_in_headers = {"authorization": "expired_token"}
+    new_client._get_urls = MagicMock()
+    new_client._check_user = MagicMock()
+    new_client._do_login_request = MagicMock()
+    new_client._get_user_info = MagicMock()
+    new_client._get_protocol = MagicMock()
+    new_client._check_inbox = MagicMock()
+    new_client._get_tsp_code = MagicMock(return_value=("mock_tsp", ""))
+    new_client._update_language = MagicMock()
+    new_client._bearer_login = MagicMock()
+
+    def simulate_token_expiration(*args, **kwargs):
+        # We need appSignedGet to return "Token expired" the first time,
+        # and success the second time.
+        if simulate_token_expiration.call_count == 0:
+            simulate_token_expiration.call_count += 1
+            return {"msg": "Token expired"}
+        return {"success": True, "data": "refreshed_data"}
+
+    simulate_token_expiration.call_count = 0
+
+    # Mock zeekr_app_sig.sign_request to just return the prep
+    from unittest.mock import patch
+    with patch("zeekr_ev_api.network._safe_json", side_effect=simulate_token_expiration), \
+         patch("zeekr_ev_api.zeekr_app_sig.sign_request", return_value=MagicMock()):
+
+        # This will trigger appSignedGet -> sees "Token expired" -> calls client.login(relogin=True)
+        # Because we have the password in session_data, the login should succeed.
+        result = appSignedGet(new_client, "http://mock/url")
+
+        assert result.get("success") is True
+        assert result.get("data") == "refreshed_data"
+        # Verify that login was actually called (which means _do_login_request was called)
+        new_client._do_login_request.assert_called_once()


### PR DESCRIPTION
This PR addresses a user-reported bug where timing out mid-session would cause subsequent requests to fail with an `AuthException`. This occurred because the `client.login(relogin=True)` function requires `self.password`, which wasn't saved in `export_session()` or parsed in `load_session()`. The plaintext password is now purposefully retained in the exported session dictionary (a security tradeoff explicitly accepted by the user) to enable transparent automatic token refresh workflows. Tests have been added to verify correctness.

---
*PR created automatically by Jules for task [3143723486200585581](https://jules.google.com/task/3143723486200585581)*