### PR TITLE
Add a configurable request timeout to all HTTP calls

### DIFF
--- a/src/zeekr_ev_api/client.py
+++ b/src/zeekr_ev_api/client.py
@@ -36,12 +36,17 @@ class ZeekrClient:
         vin_iv: str = "",
         session_data: dict | None = None,
         logger: logging.Logger | None = None,
+        timeout: tuple[float, float] | float | None = None,
     ) -> None:
         """
         Initializes the client.
         """
         self.session: requests.Session = requests.Session()
         self.password: str | None = password
+
+        # (connect, read) timeout in seconds applied to every request. Guards
+        # against a hung request (e.g. a sleeping vehicle) blocking the caller.
+        self.timeout = timeout if timeout is not None else const.REQUEST_TIMEOUT
 
         # Logger for this client (allows caller to inject their logger)
         self.logger = logger or logging.getLogger(__name__)
@@ -280,7 +285,7 @@ class ZeekrClient:
             req, self.hmac_access_key, self.hmac_secret_key
         )
         prepped = self.session.prepare_request(new_req)
-        resp = self.session.send(prepped)
+        resp = self.session.send(prepped, timeout=self.timeout)
         login_data = resp.json()
 
         if not login_data or not login_data.get("success", False):

--- a/src/zeekr_ev_api/const.py
+++ b/src/zeekr_ev_api/const.py
@@ -36,6 +36,11 @@ SET_TRAVEL_PLAN_URL = "ms-charge-manage/api/v1.0/charge/setTravelPlan"
 JOURNEY_LOG_URL = "ms-vehicle-trail/v1.0/journalLog/trip/listForPage"
 TRIP_TRACKPOINTS_URL = "ms-vehicle-trail/v1.0/journalLog/trackpoint/list"
 
+# Default (connect, read) timeout in seconds applied to every HTTP request.
+# Prevents a hung request (e.g. a sleeping vehicle that never responds) from
+# blocking the caller indefinitely. Callers can override via ZeekrClient(timeout=...).
+REQUEST_TIMEOUT = (10, 30)
+
 COUNTRY_CODE = "AU"
 REGION_CODE = "SEA"
 

--- a/src/zeekr_ev_api/network.py
+++ b/src/zeekr_ev_api/network.py
@@ -46,7 +46,9 @@ def customPost(client: "ZeekrClient", url: str, body: dict | None = None) -> Any
     req = zeekr_hmac.generateHMAC(req, client.hmac_access_key, client.hmac_secret_key)
 
     prepped = client.session.prepare_request(req)
-    resp = client.session.send(prepped)
+    resp = client.session.send(
+        prepped, timeout=getattr(client, "timeout", const.REQUEST_TIMEOUT)
+    )
     logger.debug("------ HEADERS ------")
     logger.debug(resp.headers)
     logger.debug("------ RESPONSE ------")
@@ -64,7 +66,9 @@ def customGet(client: "ZeekrClient", url: str) -> Any:
     req = zeekr_hmac.generateHMAC(req, client.hmac_access_key, client.hmac_secret_key)
 
     prepped = client.session.prepare_request(req)
-    resp = client.session.send(prepped)
+    resp = client.session.send(
+        prepped, timeout=getattr(client, "timeout", const.REQUEST_TIMEOUT)
+    )
     logger.debug("------ HEADERS ------")
     logger.debug(resp.headers)
     logger.debug("------ RESPONSE ------")
@@ -100,7 +104,9 @@ def appSignedPost(
         logger.debug(f"  {k}: {v}")
     logger.debug(f"Body: {final.body or ''}")
 
-    resp = client.session.send(final)
+    resp = client.session.send(
+        final, timeout=getattr(client, "timeout", const.REQUEST_TIMEOUT)
+    )
     logger.debug("------ HEADERS ------")
     logger.debug(resp.headers)
     logger.debug("------ RESPONSE ------")
@@ -140,7 +146,9 @@ def appSignedGet(
     prepped = client.session.prepare_request(req)
 
     final = zeekr_app_sig.sign_request(prepped, client.prod_secret)
-    resp = client.session.send(final)
+    resp = client.session.send(
+        final, timeout=getattr(client, "timeout", const.REQUEST_TIMEOUT)
+    )
     logger.debug("------ HEADERS ------")
     logger.debug(resp.headers)
     logger.debug("------ RESPONSE ------")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -255,3 +255,33 @@ def test_load_session_preserves_passed_password(mock_client):
     assert new_client.username == "test_user"
     assert new_client.password == "explicit_password"
     assert new_client.logged_in is True
+
+
+def test_default_request_timeout_applied(mock_client):
+    """Every request passes the default timeout to session.send."""
+    from zeekr_ev_api import network
+
+    mock_client.session.send.return_value.json.return_value = {
+        "success": True,
+        "data": {},
+    }
+    network.customGet(mock_client, "https://mock.server/x")
+
+    assert (
+        mock_client.session.send.call_args.kwargs.get("timeout")
+        == const.REQUEST_TIMEOUT
+    )
+
+
+def test_request_timeout_override():
+    """A caller-supplied timeout overrides the default."""
+    client = ZeekrClient(
+        username="test@example.com",
+        password="password",
+        hmac_access_key="key",
+        hmac_secret_key="secret",
+        password_public_key="pubkey",
+        prod_secret="prodsecret",
+        timeout=5,
+    )
+    assert client.timeout == 5


### PR DESCRIPTION
Hi! First off — thanks for this. I'm a happy user of the Home Assistant integration you built on top of this library (`zeekr_homeassistant`), and while reading through the library underneath it I did a small reliability pass. 🙏

I noticed none of the `session.send()` calls set a `timeout`. With a `requests` session that means a hung request — e.g. a slow or unresponsive cloud gateway — can block the calling thread indefinitely. In a Home Assistant `cloud_polling` integration that ties up an executor thread and tends to surface as entities going "unknown"/stuck.

This PR adds a default `(connect, read)` timeout to every request, overridable per client:

- `const.REQUEST_TIMEOUT = (10, 30)`
- `ZeekrClient(..., timeout=...)`, stored as `self.timeout`, defaulting to `REQUEST_TIMEOUT`
- every `session.send()` now passes `timeout=` (the network helpers read it off the client; login uses `self.timeout`)
- two small tests (default applied + caller override)

I kept the footprint minimal and matched the surrounding style (deliberately didn't run `black` across existing files, to avoid unrelated churn). Very open to a different default value or a different way to thread the override — happy to adjust.

---

**A heads-up:** this came out of a slightly larger reliability/ergonomics review, and I have a handful of other small, self-contained improvements ready (each with tests), namely:

- retry + backoff on transient errors (5xx/429/connection)
- a slightly broader token-refresh trigger (401 + a few message variants, not just the exact `"Token expired"` string)
- a stable per-account `x-device-id` (it's currently randomised per process)
- typed remote-control helpers (`set_charging_limit`, `start_charging`/`stop_charging`, defrost, sentry, …) so callers don't hand-assemble `serviceParameters`
- an opt-in confirmation poll so `stop_charging` is as reliable as `start` (would fix the stop-revert in Fryyyyy/zeekr_homeassistant#117 at the library level)

Would you prefer those as **separate focused PRs** (one per change), or **bundled** into one? Totally your call — and no worries at all if some of them aren't a direction you want. Thanks for considering! 🙏
