### PR TITLE
Retry transient request failures with backoff

### DIFF
--- a/src/zeekr_ev_api/client.py
+++ b/src/zeekr_ev_api/client.py
@@ -11,6 +11,8 @@ import warnings
 from typing import Any, Dict, List
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from Crypto.Cipher import PKCS1_v1_5
 from Crypto.PublicKey import RSA
 
@@ -37,6 +39,8 @@ class ZeekrClient:
         session_data: dict | None = None,
         logger: logging.Logger | None = None,
         timeout: tuple[float, float] | float | None = None,
+        max_retries: int | None = None,
+        retry_backoff: float | None = None,
     ) -> None:
         """
         Initializes the client.
@@ -47,6 +51,32 @@ class ZeekrClient:
         # (connect, read) timeout in seconds applied to every request. Guards
         # against a hung request (e.g. a sleeping vehicle) blocking the caller.
         self.timeout = timeout if timeout is not None else const.REQUEST_TIMEOUT
+
+        # Retry transient failures (connection drops, read timeouts, 429/5xx)
+        # with exponential backoff, honouring Retry-After. Only idempotent
+        # methods (GET/HEAD) are retried on a bad status or read timeout, so a
+        # command POST is never re-issued after the gateway may already have
+        # accepted it; a connection error (request never reached the server) is
+        # safe to retry for any method. Mounting on the session means every
+        # request — including the existing token-expiry relogin path — is
+        # covered without touching each call site.
+        self.max_retries = (
+            max_retries if max_retries is not None else const.MAX_RETRIES
+        )
+        self.retry_backoff = (
+            retry_backoff if retry_backoff is not None else const.RETRY_BACKOFF
+        )
+        retry = Retry(
+            total=self.max_retries,
+            backoff_factor=self.retry_backoff,
+            status_forcelist=const.RETRY_STATUS_FORCELIST,
+            allowed_methods=frozenset(["GET", "HEAD"]),
+            respect_retry_after_header=True,
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
 
         # Logger for this client (allows caller to inject their logger)
         self.logger = logger or logging.getLogger(__name__)

--- a/src/zeekr_ev_api/const.py
+++ b/src/zeekr_ev_api/const.py
@@ -41,6 +41,16 @@ TRIP_TRACKPOINTS_URL = "ms-vehicle-trail/v1.0/journalLog/trackpoint/list"
 # blocking the caller indefinitely. Callers can override via ZeekrClient(timeout=...).
 REQUEST_TIMEOUT = (10, 30)
 
+# Transient-failure retry policy, applied via a urllib3 Retry mounted on the
+# session. Retries connection errors and 429/5xx responses with exponential
+# backoff. Only idempotent methods (GET/HEAD) are retried on a bad status or
+# read timeout, so a command POST is never re-issued after the gateway may
+# already have accepted it. Callers can override via ZeekrClient(max_retries=,
+# retry_backoff=).
+MAX_RETRIES = 2
+RETRY_BACKOFF = 0.5
+RETRY_STATUS_FORCELIST = (429, 500, 502, 503, 504)
+
 COUNTRY_CODE = "AU"
 REGION_CODE = "SEA"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -285,3 +285,53 @@ def test_request_timeout_override():
         timeout=5,
     )
     assert client.timeout == 5
+
+
+def _make_client(**kwargs):
+    return ZeekrClient(
+        username="test@example.com",
+        password="password",
+        hmac_access_key="key",
+        hmac_secret_key="secret",
+        password_public_key="pubkey",
+        prod_secret="prodsecret",
+        **kwargs,
+    )
+
+
+def test_retry_adapter_mounted_with_expected_policy():
+    """A urllib3 Retry is mounted on the session for http(s) with our policy."""
+    client = _make_client()
+
+    for scheme in ("https://x", "http://x"):
+        retry = client.session.get_adapter(scheme).max_retries
+        assert retry.total == const.MAX_RETRIES
+        assert retry.backoff_factor == const.RETRY_BACKOFF
+        assert tuple(retry.status_forcelist) == const.RETRY_STATUS_FORCELIST
+        # Only idempotent methods are retried; a command POST is never re-issued.
+        assert retry.allowed_methods == frozenset(["GET", "HEAD"])
+        assert retry.respect_retry_after_header is True
+        # A final bad status flows through to JSON parsing rather than raising.
+        assert retry.raise_on_status is False
+
+
+def test_retry_policy_overridable():
+    """max_retries / retry_backoff override the defaults."""
+    client = _make_client(max_retries=5, retry_backoff=1.5)
+
+    assert client.max_retries == 5
+    assert client.retry_backoff == 1.5
+    retry = client.session.get_adapter("https://x").max_retries
+    assert retry.total == 5
+    assert retry.backoff_factor == 1.5
+
+
+def test_retry_only_idempotent_methods_on_bad_status():
+    """GET/HEAD retry on 429/5xx; a command POST does not; 4xx never retries."""
+    retry = _make_client().session.get_adapter("https://x").max_retries
+
+    for status in const.RETRY_STATUS_FORCELIST:
+        assert retry.is_retry("GET", status) is True
+        assert retry.is_retry("POST", status) is False
+    # A normal 4xx is a real error, not transient — never retried.
+    assert retry.is_retry("GET", 404) is False


### PR DESCRIPTION
Hi again! As you OK'd on #35, here's the retry/backoff one as its own PR. 🙏

Right now the library retries once, and only on token-expiry. There's no handling for transient failures — a connection reset, a read timeout, or a `429`/`5xx` from the gateway makes a call fail outright (which, in the HA integration, tends to cascade into entities going "unknown" for a cycle).

This adds a small `_send_with_retry` wrapper around all `session.send()` calls:

- transport errors (`ConnectionError`/`Timeout`) are retried for any method — the request didn't reach the server, so a resend is safe;
- `5xx`/`429` are retried only for idempotent methods (GET/HEAD), to avoid re-issuing a command the backend may already have accepted; honours `Retry-After`;
- conservative defaults (2 retries, 0.5s exponential backoff), overridable per client via `max_retries` / `retry_backoff`;
- 4 tests (transport retry, GET-5xx retry, POST-no-retry, exhaustion re-raise).

Composes nicely with the timeout from #35 — together they bound both each attempt and the number of attempts. Totally open to tuning the defaults or the retry policy; let me know what you'd prefer. 🙏
