### PR TITLE
Clear stale auth header on relogin

### DIFF
--- a/src/zeekr_ev_api/client.py
+++ b/src/zeekr_ev_api/client.py
@@ -192,6 +192,10 @@ class ZeekrClient:
         """
         if self.logged_in and not relogin:
             return
+        if relogin:
+            # The pre-login region lookup must not inherit a stale session
+            # authorization header from the expired session.
+            self.session.headers.pop("authorization", None)
         self._get_urls()
         self._check_user()
         self._do_login_request()


### PR DESCRIPTION
Remove the session 'authorization' header when performing a relogin to prevent pre-login region lookup from using an expired/stale authorization token. The header is popped only when relogin=True, preserving existing behavior otherwise.