### PR TITLE
Redact credentials from request and response logging

### DIFF
--- a/src/zeekr_ev_api/network.py
+++ b/src/zeekr_ev_api/network.py
@@ -4,6 +4,7 @@ import json
 
 from requests import Request
 from . import const, zeekr_app_sig, zeekr_hmac
+from .redact import redact_headers, safe_body
 from .exceptions import AuthException
 
 if TYPE_CHECKING:
@@ -11,14 +12,17 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-
 def _safe_json(resp, logger) -> Any:
     """Safely parse JSON response, logging errors."""
     try:
         return resp.json()
     except (json.JSONDecodeError, ValueError) as e:
         logger.error("Failed to decode JSON response: %s", e)
-        logger.error("Response status: %s, text: %s", resp.status_code, resp.text[:500] if resp.text else "(empty)")
+        logger.error(
+            "Response status: %s, body: %s",
+            getattr(resp, "status_code", "(unknown)"),
+            safe_body(getattr(resp, "text", None)),
+        )
         return {"success": False, "error": f"Invalid JSON response: {e}", "status_code": resp.status_code}
 
 
@@ -49,10 +53,11 @@ def customPost(client: "ZeekrClient", url: str, body: dict | None = None) -> Any
     resp = client.session.send(
         prepped, timeout=getattr(client, "timeout", const.REQUEST_TIMEOUT)
     )
-    logger.debug("------ HEADERS ------")
-    logger.debug(resp.headers)
-    logger.debug("------ RESPONSE ------")
-    logger.debug(resp.text)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("------ HEADERS ------")
+        logger.debug(redact_headers(resp.headers))
+        logger.debug("------ RESPONSE ------")
+        logger.debug(safe_body(resp.text))
 
     return _safe_json(resp, logger)
 
@@ -69,10 +74,11 @@ def customGet(client: "ZeekrClient", url: str) -> Any:
     resp = client.session.send(
         prepped, timeout=getattr(client, "timeout", const.REQUEST_TIMEOUT)
     )
-    logger.debug("------ HEADERS ------")
-    logger.debug(resp.headers)
-    logger.debug("------ RESPONSE ------")
-    logger.debug(resp.text)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("------ HEADERS ------")
+        logger.debug(redact_headers(resp.headers))
+        logger.debug("------ RESPONSE ------")
+        logger.debug(safe_body(resp.text))
 
     return _safe_json(resp, logger)
 
@@ -96,21 +102,23 @@ def appSignedPost(
 
     final = zeekr_app_sig.sign_request(prepped, client.prod_secret)
 
-    logger.debug("--- Signed Request Details ---")
-    logger.debug(f"Method: {final.method}")
-    logger.debug(f"URL: {final.url}")
-    logger.debug("Headers:")
-    for k, v in final.headers.items():
-        logger.debug(f"  {k}: {v}")
-    logger.debug(f"Body: {final.body or ''}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("--- Signed Request Details ---")
+        logger.debug(f"Method: {final.method}")
+        logger.debug(f"URL: {final.url}")
+        logger.debug("Headers:")
+        for k, v in redact_headers(final.headers).items():
+            logger.debug(f"  {k}: {v}")
+        logger.debug(f"Body: {safe_body(final.body)}")
 
     resp = client.session.send(
         final, timeout=getattr(client, "timeout", const.REQUEST_TIMEOUT)
     )
-    logger.debug("------ HEADERS ------")
-    logger.debug(resp.headers)
-    logger.debug("------ RESPONSE ------")
-    logger.debug(resp.text)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("------ HEADERS ------")
+        logger.debug(redact_headers(resp.headers))
+        logger.debug("------ RESPONSE ------")
+        logger.debug(safe_body(resp.text))
 
     result = _safe_json(resp, logger)
 
@@ -149,10 +157,11 @@ def appSignedGet(
     resp = client.session.send(
         final, timeout=getattr(client, "timeout", const.REQUEST_TIMEOUT)
     )
-    logger.debug("------ HEADERS ------")
-    logger.debug(resp.headers)
-    logger.debug("------ RESPONSE ------")
-    logger.debug(resp.text)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("------ HEADERS ------")
+        logger.debug(redact_headers(resp.headers))
+        logger.debug("------ RESPONSE ------")
+        logger.debug(safe_body(resp.text))
 
     result = _safe_json(resp, logger)
 

--- a/src/zeekr_ev_api/redact.py
+++ b/src/zeekr_ev_api/redact.py
@@ -1,0 +1,158 @@
+"""Keep credential values out of the log.
+
+Every signed request carries the live bearer token in its ``authorization``
+header, and the HMAC path carries the caller's access key and derived digest.
+All of that used to be logged verbatim. These helpers mask the values while
+keeping the surrounding structure — header names, JSON shape, sizes, a bounded
+excerpt of unparseable bodies — so debug output stays useful.
+
+Redaction is for logging only; nothing here runs on the request path.
+
+Matching is by known credential name, so it is best-effort rather than a
+guarantee. Two residues are known and deliberately not covered:
+
+* the single-use TSP code, which the gateway returns as ``data.code`` and the
+  login request sends as ``identifier``. ``identifier`` is masked; ``code`` is
+  not, because masking that substring would also hide ``countryCode``,
+  ``errorCode`` and every ``code: 200``.
+* credentials interpolated into exception messages by ``client``, which reach
+  the log at ERROR without any debug logging enabled. That belongs in its own
+  change.
+
+This module imports nothing from the rest of the package: ``network`` imports
+the signing modules, so the helpers cannot be shared from there.
+"""
+
+import json
+import re
+from typing import Any
+
+REDACTED = "<redacted>"
+
+#: Longest excerpt of an unparseable body to log.
+MAX_BODY_EXCERPT = 500
+
+#: Substrings marking a header or JSON key as holding a credential. Matched
+#: against the name lowercased with "_" and "-" removed, so accessToken,
+#: access_token and X-ACCESS-TOKEN all match. Substrings rather than exact
+#: names because the shapes this gateway returns are not fully mapped, and
+#: masking a harmless field costs less than leaking a token. That does mean
+#: x-api-signature-nonce is masked too; that is fine.
+SENSITIVE_NAME_PARTS = (
+    "authorization",
+    "cookie",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "pwd",
+    "credential",
+    "apikey",
+    "accesskey",
+    "signature",
+    "hmac",
+    "sessionid",
+    "identifier",
+    "ticket",
+)
+
+_SCRUB = re.compile(
+    r"(?i)\b([a-z0-9_-]*(?:" + "|".join(SENSITIVE_NAME_PARTS) + r")[a-z0-9_-]*)"
+    r"(\"?\s*[:=]\s*\"?)([^\"&;,\s]+)"
+)
+
+
+#: A JWT anywhere in free text, which is how this gateway's bearer tokens look.
+#: Catches a token that arrives without a key name to match on.
+_JWT = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}(?:\.[A-Za-z0-9_-]+)?")
+
+
+def _is_sensitive_name(name: Any) -> bool:
+    """Return True if a header or JSON key looks like it holds a credential."""
+    if not isinstance(name, str):
+        return False
+    normalised = name.lower().replace("_", "").replace("-", "")
+    return any(part in normalised for part in SENSITIVE_NAME_PARTS)
+
+
+def redact_headers(headers) -> dict:
+    """Copy headers for logging, masking credential values but keeping names."""
+    try:
+        items = headers.items()
+    except AttributeError:
+        return {}
+    return {k: (REDACTED if _is_sensitive_name(k) else v) for k, v in items}
+
+
+def redact(value: Any) -> Any:
+    """Recursively mask credential values in a decoded JSON structure."""
+    if isinstance(value, dict):
+        return {k: (REDACTED if _is_sensitive_name(k) else redact(v)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact(v) for v in value]
+    return value
+
+
+def redact_header_lines(text: str) -> str:
+    """Mask values in a "name:value\\n" block, such as a signature base string.
+
+    Only lines whose prefix is a credential-looking header name are touched, so
+    the query string, body hash, method and path in the same blob are left
+    alone.
+    """
+    if not isinstance(text, str):
+        return text
+    lines = []
+    for line in text.split("\n"):
+        name, sep, _value = line.partition(":")
+        if sep and _is_sensitive_name(name.strip()):
+            lines.append(f"{name}{sep}{REDACTED}")
+        else:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def scrub_text(text: str) -> str:
+    """Mask name=value and name:value pairs in text that is not JSON.
+
+    Covers form-encoded bodies and gateway error pages that echo a parameter
+    back. Anything it does not recognise is left readable on purpose — the
+    excerpt is what makes a 502 diagnosable.
+    """
+    if not isinstance(text, str):
+        return text
+    text = _SCRUB.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTED}", text)
+    return _JWT.sub(REDACTED, text)
+
+
+def safe_body(body) -> str:
+    """Render a request or response body for logging, with credentials masked.
+
+    JSON objects and arrays are re-serialised with credential values replaced.
+    Anything else — an HTML error page, a form-encoded body, a bare string — is
+    scrubbed for name/value pairs and truncated, so a failing gateway is still
+    diagnosable without risking a token.
+    """
+    if not body:
+        return "(empty)"
+    try:
+        parsed = json.loads(body)
+    except (json.JSONDecodeError, ValueError, TypeError, UnicodeDecodeError):
+        parsed = None
+    # A bare JSON scalar carries no key to match on, so treat it as text.
+    if isinstance(parsed, (dict, list)):
+        return json.dumps(redact(parsed))
+
+    if isinstance(body, bytes):
+        try:
+            body = body.decode("utf-8", "replace")
+        except (UnicodeDecodeError, AttributeError):  # pragma: no cover - defensive
+            pass
+    if not isinstance(body, str):
+        if hasattr(body, "__len__"):
+            return f"(unparsed body, {len(body)} bytes)"
+        return f"(unparsed body, {type(body).__name__})"
+
+    excerpt = scrub_text(body[:MAX_BODY_EXCERPT])
+    suffix = "…" if len(body) > MAX_BODY_EXCERPT else ""
+    return f"{excerpt}{suffix}"

--- a/src/zeekr_ev_api/zeekr_app_sig.py
+++ b/src/zeekr_ev_api/zeekr_app_sig.py
@@ -3,6 +3,8 @@ import hashlib
 import hmac
 import json
 import logging
+
+from .redact import redact_header_lines, redact_headers
 import time
 import uuid
 
@@ -203,9 +205,10 @@ def calculate_sig(request: PreparedRequest, secret: str) -> str:
 
     signature_base_string = "".join(sig_base_list)
 
-    log.debug("--- DEBUG: SIGNATURE BASE STRING ---")
-    log.debug(signature_base_string)
-    log.debug("-----------------------------------")
+    if log.isEnabledFor(logging.DEBUG):
+        log.debug("--- DEBUG: SIGNATURE BASE STRING ---")
+        log.debug(redact_header_lines(signature_base_string))
+        log.debug("-----------------------------------")
 
     # 6. Calculate HMAC-SHA256
     h = hmac.new(
@@ -244,6 +247,7 @@ def sign_request(request: PreparedRequest, secret: str) -> PreparedRequest:
     signature = calculate_sig(request, secret)
     request.headers["X-SIGNATURE"] = signature
 
-    log.debug(f"Request Headers: {request.headers}")
+    if log.isEnabledFor(logging.DEBUG):
+        log.debug(f"Request Headers: {redact_headers(request.headers)}")
 
     return request

--- a/src/zeekr_ev_api/zeekr_hmac.py
+++ b/src/zeekr_ev_api/zeekr_hmac.py
@@ -3,6 +3,8 @@ import datetime
 import hashlib
 import hmac
 import logging
+
+from .redact import redact_headers
 from typing import Dict
 
 from urllib.parse import urlparse
@@ -116,6 +118,7 @@ def generateHMAC(request: Request, access_key: str,
     request.headers["X-HMAC-DIGEST"] = body_digest
     request.headers["X-DATE"] = gmt_date
 
-    log.debug(f"Request Headers: {request.headers}")
+    if log.isEnabledFor(logging.DEBUG):
+        log.debug(f"Request Headers: {redact_headers(request.headers)}")
 
     return request

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -1,0 +1,204 @@
+"""Credential values must not reach the log through the request layer.
+
+The end-to-end tests are the point: they drive real request functions with
+logging at DEBUG and assert the secrets are absent. The unit tests below only
+explain why it holds. Two residues are known and out of scope here, documented
+in redact.py: the TSP `data.code`, and credentials that `client` interpolates
+into exception messages.
+"""
+
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from zeekr_ev_api import network
+from zeekr_ev_api.network import _safe_json
+from zeekr_ev_api.redact import (
+    REDACTED,
+    redact,
+    redact_header_lines,
+    redact_headers,
+    safe_body,
+)
+
+TOKEN = "eyJhbGciOiJIUzI1NiJ9.super-secret-session-token"
+ACCESS_KEY = "AK-super-secret-access-key"
+SECRET_KEY = "SK-super-secret-secret-key"
+
+
+def _client() -> MagicMock:
+    """A client whose session echoes a harmless JSON response."""
+    client = MagicMock()
+    client.logger = logging.getLogger("zeekr_ev_api.network")
+    client.bearer_token = TOKEN
+    client.logged_in_headers = {"authorization": TOKEN, "content-type": "application/json"}
+    client.prod_secret = "prod-secret"
+    client.hmac_access_key = ACCESS_KEY
+    client.hmac_secret_key = SECRET_KEY
+    client.timeout = (10, 30)
+
+    resp = MagicMock()
+    resp.json.return_value = {"code": 200, "data": {"accessToken": TOKEN}}
+    resp.text = json.dumps({"code": 200, "data": {"accessToken": TOKEN}})
+    resp.headers = {"content-type": "application/json", "set-cookie": f"session={TOKEN}"}
+    resp.status_code = 200
+    client.session.send.return_value = resp
+    client.session.prepare_request.side_effect = lambda r: requests.Session().prepare_request(r)
+    return client
+
+
+# --- end-to-end: the property that actually matters -------------------------
+
+
+@pytest.mark.parametrize("call", ["appSignedGet", "appSignedPost"])
+def test_signed_requests_never_log_the_bearer_token(caplog, call):
+    caplog.set_level(logging.DEBUG)
+    getattr(network, call)(_client(), "https://example.invalid/api/v1/status")
+    assert TOKEN not in caplog.text
+    assert REDACTED in caplog.text
+
+
+@pytest.mark.parametrize("call", ["customGet", "customPost"])
+def test_hmac_requests_never_log_the_hmac_secrets(caplog, call):
+    caplog.set_level(logging.DEBUG)
+    getattr(network, call)(_client(), "https://example.invalid/api/v1/login")
+    assert ACCESS_KEY not in caplog.text
+    assert "X-HMAC-ACCESS-KEY" in caplog.text, "the header name should stay visible"
+    assert REDACTED in caplog.text
+
+
+def test_the_signature_base_string_does_not_leak_the_token(caplog):
+    """The base string is built from the canonical headers, authorization included."""
+    caplog.set_level(logging.DEBUG)
+    network.appSignedGet(_client(), "https://example.invalid/api/v1/status")
+    base_string_lines = [r.message for r in caplog.records if "authorization:" in r.message]
+    assert base_string_lines, "expected the signature base string to be logged"
+    assert all(TOKEN not in line for line in base_string_lines)
+
+
+# --- unit level -------------------------------------------------------------
+
+
+def test_redact_headers_masks_credentials_but_keeps_the_names():
+    out = redact_headers({"Authorization": TOKEN, "content-type": "application/json"})
+    assert out["Authorization"] == REDACTED
+    assert out["content-type"] == "application/json"
+
+
+def test_redact_headers_covers_the_hmac_headers():
+    out = redact_headers({"X-HMAC-ACCESS-KEY": ACCESS_KEY, "X-HMAC-SIGNATURE": "sig"})
+    assert set(out.values()) == {REDACTED}
+
+
+def test_redact_headers_accepts_a_case_insensitive_dict():
+    """Every real call site passes requests' CaseInsensitiveDict, not a plain dict."""
+    headers = requests.structures.CaseInsensitiveDict({"authorization": TOKEN})
+    assert redact_headers(headers)["authorization"] == REDACTED
+
+
+def test_redact_masks_token_keys_in_any_spelling_and_depth():
+    out = redact(
+        {
+            "code": 200,
+            "data": {
+                "accessToken": TOKEN,
+                "refresh_token": "r",
+                "tokenValue": TOKEN,
+                "profile": {"name": "Pieter", "password": "hunter2"},
+                "sessions": [{"idToken": TOKEN}],
+            },
+        }
+    )
+    assert out["code"] == 200
+    assert out["data"]["profile"]["name"] == "Pieter"
+    assert out["data"]["profile"]["password"] == REDACTED
+    assert TOKEN not in json.dumps(out)
+    assert out["data"]["tokenValue"] == REDACTED
+    assert out["data"]["sessions"][0]["idToken"] == REDACTED
+
+
+def test_redact_header_lines_masks_only_credential_lines():
+    base = f"authorization:{TOKEN}\nx-timestamp:123\nGET\n/api/v1/status"
+    out = redact_header_lines(base)
+    assert TOKEN not in out
+    assert "x-timestamp:123" in out
+    assert "/api/v1/status" in out
+    assert "GET" in out
+
+
+def test_safe_body_masks_json_and_survives_everything_else():
+    assert TOKEN not in safe_body(json.dumps({"data": {"accessToken": TOKEN}}))
+    assert REDACTED in safe_body(json.dumps({"accessToken": TOKEN}))
+    assert safe_body(None) == "(empty)"
+    assert safe_body("") == "(empty)"
+    # Non-JSON is kept readable on purpose; that excerpt is what makes a 502 diagnosable.
+    html = "<html>gateway error</html>"
+    assert safe_body(html) == html
+
+
+def test_safe_body_actually_parses_bytes():
+    rendered = safe_body(json.dumps({"accessToken": TOKEN}).encode())
+    assert TOKEN not in rendered
+    assert REDACTED in rendered, "bytes must be parsed and redacted, not fall through"
+
+
+@pytest.mark.parametrize("body", [12345, iter([b"chunk"]), object()])
+def test_safe_body_never_raises_on_an_unusual_body(body):
+    """requests accepts ints, iterators and file objects as data=."""
+    assert "unparsed body" in safe_body(body)
+
+
+def test_safe_json_error_path_does_not_log_the_body_verbatim():
+    resp = MagicMock()
+    resp.json.side_effect = ValueError("Expecting value")
+    resp.status_code = 502
+    resp.text = f"<html>gateway error, trace-id=abc123, token={TOKEN}</html>"
+    logger = MagicMock()
+
+    result = _safe_json(resp, logger)
+
+    assert result["success"] is False
+    assert result["status_code"] == 502
+    logged = " ".join(str(a) for call in logger.error.call_args_list for a in call.args)
+    assert TOKEN not in logged
+    assert "trace-id=abc123" in logged, "a 502 must stay diagnosable"
+
+
+def test_safe_json_returns_parsed_json_untouched():
+    resp = MagicMock()
+    resp.json.return_value = {"data": {"accessToken": TOKEN}}
+    # Redaction is for logging only — callers still need the real token.
+    assert _safe_json(resp, MagicMock())["data"]["accessToken"] == TOKEN
+
+
+def test_x_signature_header_is_masked():
+    """X-SIGNATURE is added by sign_request and had no coverage."""
+    assert redact_headers({"X-SIGNATURE": "sig-value"})["X-SIGNATURE"] == REDACTED
+
+
+def test_safe_body_keeps_a_bounded_excerpt_of_non_json():
+    html = "<html>upstream connect error: connection timeout; trace-id=abc123</html>"
+    assert "trace-id=abc123" in safe_body(html)
+
+
+def test_safe_body_scrubs_form_encoded_credentials():
+    rendered = safe_body(f"user=pieter&access_token={TOKEN}&lang=nl")
+    assert TOKEN not in rendered
+    assert "user=pieter" in rendered
+    assert "lang=nl" in rendered
+
+
+def test_safe_body_masks_a_token_with_no_key_to_match_on():
+    """A bare JSON scalar, or a token echoed inside an error page."""
+    assert TOKEN not in safe_body(f'"{TOKEN}"')
+    assert TOKEN not in safe_body(f"<html>session expired: {TOKEN}</html>")
+    assert REDACTED in safe_body(f'"{TOKEN}"')
+
+
+def test_safe_body_truncates_a_long_body():
+    rendered = safe_body("x" * 2000)
+    assert len(rendered) <= 520
+    assert rendered.endswith("\u2026")


### PR DESCRIPTION
Enabling debug logging on this library writes the live bearer token into the consumer's log on every signed request. Three places:

- `calculate_sig` logs the signature base string, and since `authorization` is in `ALLOWED_HEADERS` that string literally contains `authorization:<token>`
- `sign_request` and `generateHMAC` each log the whole signed header dict — the token, `X-SIGNATURE`, and the `X-HMAC-ACCESS-KEY` / `X-HMAC-SIGNATURE` / `X-HMAC-DIGEST` triple
- `network` logs request and response bodies in full, which covers the login response and its `accessToken`

And `_safe_json`'s decode-failure path logged up to 500 characters of the body at ERROR, so that one needs no debug logging at all to fire.

The token isn't read-only — the same session does remote unlock, climate and charge control. Home Assistant consumers ship `home-assistant.log` in full backups and in Download Diagnostics.

## Fix

A small `redact` module, used at every logging site. Values are masked rather than dropped, so header names, JSON shape and status codes stay readable.

Bodies that aren't JSON keep a bounded excerpt with name/value pairs scrubbed. I didn't want to just drop them — that excerpt is what makes a 502 diagnosable. A JWT is masked wherever it appears, since a token can arrive with no key to match on.

The helpers are in their own module because `network` imports the signing modules, so they can't be shared from there.

Debug blocks are now behind `isEnabledFor(DEBUG)`. Arguments get evaluated regardless of level, and redacting costs meaningfully more than the `str()` it replaces.

## Tests

Five of them drive the real request functions with logging at DEBUG and assert the secrets are absent. I checked they fail against each of the three sites above, so they pin the behaviour rather than the implementation.

## Left alone on purpose

Both noted in the module rather than left silent:

- The TSP code — `data.code` in the response, `identifier` in the request. `identifier` is masked; `code` isn't, because that substring would also hide `countryCode`, `errorCode` and every `code: 200`.
- Credentials that `client` interpolates into exception messages, which reach the log at ERROR through `_refresh_token`. Separate change — happy to do that one too if you want it.

Nothing on the request path changes, and `_safe_json` still returns the parsed body untouched to callers.
